### PR TITLE
Navigate to Specific Problem via URL Parameters

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,6 +1,7 @@
-// Arguments for specific problem category and id
-const category_arg = "category";
-const problem_id_arg = "problemID";
+// Argument names for specific problem category and id
+const CATEGORY_ARG = "category";
+const PROBLEM_ID_ARG = "problem";
+const PRACTICUM_URL = "https://awb-carleton.github.io/practicum/";
 
 // from https://css-tricks.com/snippets/javascript/get-url-variables/
 // doesn't handle every valid query string, but should work for our purposes
@@ -531,12 +532,13 @@ var csed = (function() {
 
 function onProblemStart(problem) {
     csed.loadProblem(problem);
+    csed.setProblemToLoad(problem.category, problem.id); // setting this allows the click to copy button to read it
 }
 
 // Checks for arguments in the URL asking for a specific problem
 function checkForSpecificProblemArg() {
-    const category_value = getQueryVariable(category_arg);
-    const problem_id_value = getQueryVariable(problem_id_arg);
+    const category_value = getQueryVariable(CATEGORY_ARG);
+    const problem_id_value = getQueryVariable(PROBLEM_ID_ARG);
     if (category_value && problem_id_value) {
         csed.setProblemToLoad(category_value, problem_id_value);
     }
@@ -597,6 +599,19 @@ $(document).ready(function() {
                 } else {
                     csed.showHome();
                 }
+                
+                // Adding a button to copy a link to the current problem
+                let link_button = document.createElement("button"); 
+                link_button.innerHTML = "Copy link to problem";
+                link_button.onclick = function () {
+                    var problem = csed.getProblemToLoad(categoryConfig);                    
+                    let category = problem.category;
+                    let problemID = problem.id;
+                    let link = PRACTICUM_URL + "?category=" + category + "&problem=" + problemID;
+                    navigator.clipboard.writeText(link);        
+                    console.log("copied! " + link);
+                };
+                document.body.appendChild(link_button);
             }
         })
         .fail(function () {

--- a/js/index.js
+++ b/js/index.js
@@ -350,7 +350,7 @@ var csed = (function() {
         const url = new URL(window.location);
         url.searchParams.set(CATEGORY_PARAMETER, problem.category);
         url.searchParams.set(PROBLEM_ID_PARAMETER, problem.id);
-        window.history.pushState({}, '', url);
+        window.history.replaceState({}, '', url);
     }
 
     function loadProblem(problemConfig, variant) {
@@ -540,7 +540,6 @@ var csed = (function() {
 
 function onProblemStart(problem) {
     csed.loadProblem(problem);
-    csed.setProblemToLoad(problem.category, problem.id); // setting this allows the click to copy button to read it
 }
 
 // Checks for arguments in the URL asking for a specific problem
@@ -564,11 +563,12 @@ $(document).ready(function() {
             .addClass("col-sm-6");
     });
     
+    //TODO:
     // Detect change in active history entry. Only triggered by browser actions or by calling history.back()
     // https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onpopstate
-    $(window).on('popstate', function() {
-        location.reload(true); // Reload the page to load the problem that was navigated back to.
-    });      
+    // $(window).on('popstate', function() {
+    //     location.reload(true); // Reload the page to load the problem that was navigated back to.
+    // });      
 
     var username = csed.getUsername();
     var forceUser = getQueryVariable("username");
@@ -613,21 +613,6 @@ $(document).ready(function() {
                 } else {
                     csed.showHome();
                 }
-                
-                // Adding a button to copy a link to the current problem
-                let link_button = document.createElement("button"); 
-                link_button.innerHTML = "Copy link to problem";
-                link_button.onclick = function () {
-                    var problem = csed.getProblemToLoad(categoryConfig);                    
-                    let category = problem.category;
-                    let problemID = problem.id;
-                    let url = window.location.href.split('?')[0];
-                    let problem_link = url + "?category=" + category + "&problem=" + problemID;
-                    navigator.clipboard.writeText(problem_link);        
-                    console.log("copied! " + problem_link);
-                };
-                document.body.appendChild(link_button);
-                //TODO: hide this copy link to problem button on the home screen
             }
         })
         .fail(function () {

--- a/js/index.js
+++ b/js/index.js
@@ -344,10 +344,18 @@ var csed = (function() {
         }
 
     }
+    
+    // Pushes the identifier of the problem into the browser's url
+    function setUrlArgs(problem) {
+        const url = new URL(window.location);
+        url.searchParams.set(CATEGORY_PARAMETER, problem.category);
+        url.searchParams.set(PROBLEM_ID_PARAMETER, problem.id);
+        window.history.pushState({}, '', url);
+    }
 
     function loadProblem(problemConfig, variant) {
         task_logger = Logging.start_task(problemConfig);
-
+        
         // if no alt state, choose the first
         if (problemConfig.content.variants) {
             variant = variant || problemConfig.content.variants[0];
@@ -357,7 +365,8 @@ var csed = (function() {
                 detail: {id: variant.id},
             });
         }
-
+        
+        setUrlArgs(problemConfig);
         saveProblemData(problemConfig);
         updateProblemDisplay(problemConfig);
 
@@ -554,6 +563,12 @@ $(document).ready(function() {
             .removeClass("col-sm-12")
             .addClass("col-sm-6");
     });
+    
+    // Detect change in active history entry. Only triggered by browser actions or by calling history.back()
+    // https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onpopstate
+    $(window).on('popstate', function() {
+        location.reload(true); // Reload the page to load the problem that was navigated back to.
+    });      
 
     var username = csed.getUsername();
     var forceUser = getQueryVariable("username");

--- a/js/index.js
+++ b/js/index.js
@@ -1,7 +1,6 @@
-// Argument names for specific problem category and id
-const CATEGORY_ARG = "category";
-const PROBLEM_ID_ARG = "problem";
-const PRACTICUM_URL = "https://awb-carleton.github.io/practicum/";
+// Parameter names for specific problem category and id
+const CATEGORY_PARAMETER = "category";
+const PROBLEM_ID_PARAMETER = "problem";
 
 // from https://css-tricks.com/snippets/javascript/get-url-variables/
 // doesn't handle every valid query string, but should work for our purposes
@@ -536,9 +535,9 @@ function onProblemStart(problem) {
 }
 
 // Checks for arguments in the URL asking for a specific problem
-function checkForSpecificProblemArg() {
-    const category_value = getQueryVariable(CATEGORY_ARG);
-    const problem_id_value = getQueryVariable(PROBLEM_ID_ARG);
+function checkForSpecificProblemUrlParameters() {
+    const category_value = getQueryVariable(CATEGORY_PARAMETER);
+    const problem_id_value = getQueryVariable(PROBLEM_ID_PARAMETER);
     if (category_value && problem_id_value) {
         csed.setProblemToLoad(category_value, problem_id_value);
     }
@@ -607,11 +606,13 @@ $(document).ready(function() {
                     var problem = csed.getProblemToLoad(categoryConfig);                    
                     let category = problem.category;
                     let problemID = problem.id;
-                    let link = PRACTICUM_URL + "?category=" + category + "&problem=" + problemID;
-                    navigator.clipboard.writeText(link);        
-                    console.log("copied! " + link);
+                    let url = window.location.href.split('?')[0];
+                    let problem_link = url + "?category=" + category + "&problem=" + problemID;
+                    navigator.clipboard.writeText(problem_link);        
+                    console.log("copied! " + problem_link);
                 };
                 document.body.appendChild(link_button);
+                //TODO: hide this copy link to problem button on the home screen
             }
         })
         .fail(function () {
@@ -624,8 +625,8 @@ $(document).ready(function() {
         d3.select("#main-page").classed("hidden", false);
     });
     
-    // Check for arguments in url
-    checkForSpecificProblemArg();
+    // Check for parameters in url
+    checkForSpecificProblemUrlParameters();
 });
 
 (function($) {

--- a/js/index.js
+++ b/js/index.js
@@ -1,3 +1,6 @@
+// Arguments for specific problem category and id
+const category_arg = "category";
+const problem_id_arg = "problemID";
 
 // from https://css-tricks.com/snippets/javascript/get-url-variables/
 // doesn't handle every valid query string, but should work for our purposes
@@ -136,18 +139,20 @@ var csed = (function() {
         d3.select("#problem-container .problem").remove();
     }
 
-    function findProblem(categoryConfig, requestedCategory, requestedProblemId)  {
-        categoryConfig.forEach(function (category) {
-            if (category.category === requestedCategory) {
-                var problems = category['problems'];
-                problem.forEach(function (problem) {
+    function findProblem(categoryConfig, requestedCategory, requestedProblemId)  {        
+        for (let i in categoryConfig) {
+            let category = categoryConfig[i];
+            if (category.category == requestedCategory) {
+                let problems = category['problems'];
+                for (let j in problems) {
+                    let problem = problems[j];
                     if (problem.id === requestedProblemId) {
                         return problem;
                     }
-                });
+                }
             }
-        });
-        return null;
+        }
+       return null;
     }
 
     function addProblemsContentToLandingPage(problemsConfig, onProblemStartCallback) {
@@ -528,6 +533,15 @@ function onProblemStart(problem) {
     csed.loadProblem(problem);
 }
 
+// Checks for arguments in the URL asking for a specific problem
+function checkForSpecificProblemArg() {
+    const category_value = getQueryVariable(category_arg);
+    const problem_id_value = getQueryVariable(problem_id_arg);
+    if (category_value && problem_id_value) {
+        csed.setProblemToLoad(category_value, problem_id_value);
+    }
+}
+
 $(document).ready(function() {
     "use strict";
 
@@ -576,7 +590,7 @@ $(document).ready(function() {
 
                 csed.addProblemsToNav(categoryConfig, onProblemStart);
                 csed.addProblemsContentToLandingPage(categoryConfig, onProblemStart);
-
+                
                 if (csed.hasProblemToLoad(categoryConfig)) {
                     var problem = csed.getProblemToLoad(categoryConfig);
                     csed.loadProblem(problem);
@@ -594,6 +608,9 @@ $(document).ready(function() {
         $('#main-page').html('<p>Uh oh! There appears to be a problem with the server!</p><p>Our apologies, please report this with <a href="https://catalyst.uw.edu/umail/form/aaronb22/4553">our feedback form</a> and we\'ll get it fixed ASAP.</p>');
         d3.select("#main-page").classed("hidden", false);
     });
+    
+    // Check for arguments in url
+    checkForSpecificProblemArg();
 });
 
 (function($) {


### PR DESCRIPTION
### Why?
There was no way to link to a specific practice problem within practicum. This changes that.

### What changed?
There was already some functionality present in `index.js` for reading parameters from a url and setting a problem for the page to load. I added a `checkForSpecificProblemUrlParameters()` function that runs after the page loads and looks for a category and problem id number in the url.

When a new problem loads, [`history.replaceState()`](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState) changes the parameters in the url.

### Is there still work to do?
We should try to use [`history.pushState()`](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) and reload the `problem-container` when a user navigates backwards.



